### PR TITLE
Hotfix sidebar links

### DIFF
--- a/src/app/(document)/[id]/MDXSidebar.tsx
+++ b/src/app/(document)/[id]/MDXSidebar.tsx
@@ -5,6 +5,7 @@ import utils from '../../utils.module.css'
 import generateHeadingLink from "@/helpers/generateHeadingLink"
 import { MDXRemote } from "next-mdx-remote"
 import useScrollHighlight from "@/hooks/useScrollHighlight"
+import Link from "next/link"
 
 interface MDXContentProps {
   source: MDXRemoteSerializeResult,
@@ -33,9 +34,11 @@ export default function MDXSidebar({ source }: MDXContentProps) {
       const generatedLink = generateHeadingLink(props.children as string)
   
       return (
-        <a
+        <Link
+          replace
           href={`#${generatedLink}`}
           className={`${utils.monoText} ${utils.smallText}`}
+          prefetch={false}
         >
           {highlighted === generatedLink ? (
             <b>
@@ -45,7 +48,7 @@ export default function MDXSidebar({ source }: MDXContentProps) {
             props.children
           )}
           {/* {props.children} */}
-        </a>
+        </Link>
       )
     },
     p: Nothing,


### PR DESCRIPTION
- Use <Link> component with replace=true in MDX sidebar component

Fixes [this bug](https://www.notion.so/brendann/Exit-button-has-undesired-effect-if-navigation-performed-using-table-of-contents-3b932eaa85104a0ba2548f7a67eb37ce?pvs=4)