### PR TITLE
feat: hidden works

### DIFF
--- a/src/app/(default)/work/[id]/page.tsx
+++ b/src/app/(default)/work/[id]/page.tsx
@@ -17,9 +17,15 @@ export async function generateStaticParams() {
   const files = await fs.readdir(path.join(process.cwd(), 'src', 'content', 'work'))
 
   // Return relevant IDs so they can be prerendered
-  return files.map((file) => ({
+  const relevantIds = files.map((file) => ({
     id: file.split('.')[0],
   }))
+
+  if (process.env.NODE_ENV === 'production') {
+    return relevantIds.filter((obj) => !obj.id.includes('wip'))
+  }
+
+  return relevantIds
 }
 
 export default async function Work({ params }: Props) {

--- a/src/app/(default)/work/[id]/page.tsx
+++ b/src/app/(default)/work/[id]/page.tsx
@@ -28,6 +28,13 @@ export async function generateStaticParams() {
   return relevantIds
 }
 
+/**
+ * The Work page renders and displays visual projects using the `MDXContent` component.
+ * Pages are statically generated at build time from th `src/content` folder,
+ * with filenames containing "wip" filtered out at production.
+ * @param param0
+ * @returns
+ */
 export default async function Work({ params }: Props) {
   return (
     <div className={styles.container}>


### PR DESCRIPTION
- Filter out works containing "wip" in the filename/ID, when in production
  - Only for the user-facing website
  - Pages are still visible in development, and on Git