### PR TITLE
Fix anchor/hash scrolling bug

### DIFF
--- a/src/app/(document)/[id]/MDXSidebar.tsx
+++ b/src/app/(document)/[id]/MDXSidebar.tsx
@@ -26,35 +26,23 @@ const Nothing = () => <></>
 export default function MDXSidebar({ source }: MDXContentProps) {
   const highlighted = useScrollHighlight('anchorWrapper', HIGHLIGHT_TOP_MARGIN)
 
-  // Force a local refresh when the page hash changes
-  // If the hash is empty, scroll to the top of the page instead of performing
-  // a local refresh (may take a long time)
-  // See https://stackoverflow.com/questions/57656284/browser-scrolling-to-previous-position-instead-of-anchors-when-navigating-back
-  useEffect(() => {
-    window.onhashchange = function() {
-      if (window.location.hash === '' || window.location.hash === '#') {
-        window.scrollTo(0, 0)
-      } else {
-        window.location.href = window.location.href
-      }
-    }
-
-    return () => {
-      window.onhashchange = () => {}
-    }
-  }, [])
-    
   /**
    * Map of MDX components which map to React components.
    */
   const MDXComponents = {
     h1: (props: React.HTMLProps<HTMLHeadingElement>) => {
       const generatedLink = generateHeadingLink(props.children as string)
+
+      function onClick(e: any) {
+        e.preventDefault()
+        window.location.replace(`#${generatedLink}`)
+      }
   
       return (
         <a
           href={`#${generatedLink}`}
           className={`${utils.monoText} ${utils.smallText}`}
+          onClick={onClick}
         >
           {highlighted === generatedLink ? (
             <b>

--- a/src/app/(document)/[id]/MDXSidebar.tsx
+++ b/src/app/(document)/[id]/MDXSidebar.tsx
@@ -5,7 +5,7 @@ import utils from '../../utils.module.css'
 import generateHeadingLink from "@/helpers/generateHeadingLink"
 import { MDXRemote } from "next-mdx-remote"
 import useScrollHighlight from "@/hooks/useScrollHighlight"
-import Link from "next/link"
+import { useEffect } from "react"
 
 interface MDXContentProps {
   source: MDXRemoteSerializeResult,
@@ -25,6 +25,24 @@ const Nothing = () => <></>
 */
 export default function MDXSidebar({ source }: MDXContentProps) {
   const highlighted = useScrollHighlight('anchorWrapper', HIGHLIGHT_TOP_MARGIN)
+
+  // Force a local refresh when the page hash changes
+  // If the hash is empty, scroll to the top of the page instead of performing
+  // a local refresh (may take a long time)
+  // See https://stackoverflow.com/questions/57656284/browser-scrolling-to-previous-position-instead-of-anchors-when-navigating-back
+  useEffect(() => {
+    window.onhashchange = function() {
+      if (window.location.hash === '' || window.location.hash === '#') {
+        window.scrollTo(0, 0)
+      } else {
+        window.location.href = window.location.href
+      }
+    }
+
+    return () => {
+      window.onhashchange = () => {}
+    }
+  }, [])
     
   /**
    * Map of MDX components which map to React components.

--- a/src/app/(document)/[id]/MDXSidebar.tsx
+++ b/src/app/(document)/[id]/MDXSidebar.tsx
@@ -34,11 +34,9 @@ export default function MDXSidebar({ source }: MDXContentProps) {
       const generatedLink = generateHeadingLink(props.children as string)
   
       return (
-        <Link
-          replace
+        <a
           href={`#${generatedLink}`}
           className={`${utils.monoText} ${utils.smallText}`}
-          prefetch={false}
         >
           {highlighted === generatedLink ? (
             <b>
@@ -48,7 +46,7 @@ export default function MDXSidebar({ source }: MDXContentProps) {
             props.children
           )}
           {/* {props.children} */}
-        </Link>
+        </a>
       )
     },
     p: Nothing,


### PR DESCRIPTION
- Use `<a>` element instead of `<Link>` component to scroll
- Replicate previously implemented back button behavior
  - Perform replacement of history